### PR TITLE
Update/pg95

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = jdbc2_fdw
 OBJS = jdbc2_fdw.o option.o deparse.o connection.o jq.o
 
-PG_CPPFLAGS = -I$(libpq_srcdir)
+PG_CPPFLAGS = -I$(libpq_srcdir) -std=gnu99
 SHLIB_LINK = $(libpq)
 
 EXTENSION = jdbc2_fdw

--- a/jdbc2_fdw.c
+++ b/jdbc2_fdw.c
@@ -1961,15 +1961,27 @@ set_transmission_modes(void)
     if (DateStyle != USE_ISO_DATES)
         (void) set_config_option("datestyle", "ISO",
                                  PGC_USERSET, PGC_S_SESSION,
-                                 GUC_ACTION_SAVE, true, 0, false);
+                                 GUC_ACTION_SAVE, true, 0
+#if PG_VERSION_NUM >= 90500
+                                 , false
+#endif
+                                );
     if (IntervalStyle != INTSTYLE_POSTGRES)
         (void) set_config_option("intervalstyle", "postgres",
                                  PGC_USERSET, PGC_S_SESSION,
-                                 GUC_ACTION_SAVE, true, 0, false);
+                                 GUC_ACTION_SAVE, true, 0
+#if PG_VERSION_NUM >= 90500
+                                 , false
+#endif
+                                );
     if (extra_float_digits < 3)
         (void) set_config_option("extra_float_digits", "3",
                                  PGC_USERSET, PGC_S_SESSION,
-                                 GUC_ACTION_SAVE, true, 0, false);
+                                 GUC_ACTION_SAVE, true, 0
+#if PG_VERSION_NUM >= 90500
+                                 , false
+#endif
+                                );
 
     return nestlevel;
 }


### PR DESCRIPTION
Changes so jdbc2_fdw compiles for PostgreSQL 9.5. Basic foreign data wrapper and selection queries tested on revised code and postgresql 9.5.  #if directives used so code should still compile and work for 9.4.
